### PR TITLE
Fix Emoji Characters Before Inserting Post

### DIFF
--- a/daddy-heimlich/functions/class-daddio-instagram.php
+++ b/daddy-heimlich/functions/class-daddio-instagram.php
@@ -618,7 +618,7 @@ class Daddio_Instagram {
 		$posted = date( 'Y-m-d H:i:s', intval( $img->timestamp ) ); // In GMT time
 		$username = $img->owner_username;
 		$full_name = $img->owner_full_name;
-		$caption = Encoding::fixUTF8( $img->caption );
+		$caption = wp_encode_emoji( $img->caption );
 		$title = preg_replace( '/\s#\w+/i', '', $caption );
 
 		$post = array(


### PR DESCRIPTION
If an Instagram caption had an emoji in it we were forced to strip it out so the caption could be inserted into the database. To capture the emojis I would need to manually edit the inserted post after the fact. I read about [`wp_encode_emoji()`](https://developer.wordpress.org/reference/functions/wp_encode_emoji/) which can solve this issue. Yay!