### PR TITLE
Add Location Metadata for Instagram Posts

### DIFF
--- a/daddy-heimlich/functions.php
+++ b/daddy-heimlich/functions.php
@@ -114,6 +114,7 @@ $files_to_include = array(
 	'class-daddio-menus.php',
 	'class-daddio-post-galleries.php',
 	'class-daddio-instagram.php',
+	'class-daddio-instagram-locations.php',
 	'rsvp.php',
 	'class-daddio-infinite-scroll.php',
 	'class-daddio-on-this-day.php',

--- a/daddy-heimlich/functions.php
+++ b/daddy-heimlich/functions.php
@@ -118,7 +118,7 @@ $files_to_include = array(
 	'rsvp.php',
 	'class-daddio-infinite-scroll.php',
 	'class-daddio-on-this-day.php',
-	// 'cli-commands.php',
+	'cli-commands.php',
 );
 $dir = get_template_directory() . '/functions/';
 foreach ( $files_to_include as $filename ) {

--- a/daddy-heimlich/functions.php
+++ b/daddy-heimlich/functions.php
@@ -70,6 +70,37 @@ function ordinal_suffix( $n, $return_n = true ) {
 	return $return_n ? $n . $suffix : $suffix;
 }
 
+function daddio_generate_taxonomy_labels( $singular = '', $plural = '', $overrides = array() ) {
+	$lc_plural = strtolower( $plural );
+	$uc_plural = ucwords( $lc_plural );
+	$lc_singular = strtolower( $singular );
+	$uc_singular = ucwords( $lc_singular );
+
+	$labels = array(
+		'name'                       => $uc_plural,
+		'singular_name'              => $uc_singular,
+		'menu_name'                  => $uc_plural,
+		'all_items'                  => 'All ' . $uc_plural,
+		'parent_item'                => 'Parent ' . $uc_singular,
+		'parent_item_colon'          => 'Parent ' . $uc_singular . ':',
+		'new_item_name'              => 'New ' . $uc_singular . ' Name',
+		'add_new_item'               => 'Add New ' . $uc_singular,
+		'edit_item'                  => 'Edit ' . $uc_singular,
+		'update_item'                => 'Update ' . $uc_singular,
+		'view_item'                  => 'View ' . $uc_singular,
+		'separate_items_with_commas' => 'Separate ' . $lc_plural . ' with commas',
+		'add_or_remove_items'        => 'Add or remove ' . $lc_plural,
+		'choose_from_most_used'      => 'Choose from the most used',
+		'popular_items'              => 'Popular ' . $uc_plural,
+		'search_items'               => 'Search ' . $uc_plural,
+		'not_found'                  => 'Not Found',
+		'no_terms'                   => 'No ' . $lc_plural,
+		'items_list'                 => ucfirst( $lc_plural ) . ' list',
+		'items_list_navigation'      => ucfirst( $lc_plural ) . ' list navigation',
+	);
+	return wp_parse_args( $labels, $overrides );
+}
+
 // Include external libraries
 include 'vendor/ForceUTF8/Encoding.php';
 

--- a/daddy-heimlich/functions/class-daddio-instagram-locations.php
+++ b/daddy-heimlich/functions/class-daddio-instagram-locations.php
@@ -173,6 +173,9 @@ class Daddio_Instagram_Locations {
 				background-color: green;
 				color: #fff;
 			}
+			.post.success a {
+				color: #fff;
+			}
 			.post.fail {
 				background-color: red;
 				color: #fff;
@@ -219,7 +222,16 @@ class Daddio_Instagram_Locations {
 			do_action( 'daddio_after_instagram_inserted', $post_id, $node );
 			delete_post_meta( $post_id, 'needs-private-location-data' );
 		}
-		wp_send_json_success( array( 'message' => 'Success!' ) );
+
+		$locations = [];
+		$location_objs = wp_get_object_terms( $post_id, 'location' );
+		if ( ! is_wp_error( $location_objs ) ) {
+			foreach ( $location_objs as $term ) {
+				$locations[] = '<a href="' . esc_url( get_term_link( $term ) ) . '" target="_blank" rel="noopener noreferrer">' . $term->name . '</a>';
+			}
+		}
+		$locations_str = implode( ', ', $locations );
+		wp_send_json_success( array( 'message' => 'Success!<br>Location: ' . $locations_str ) );
 		die();
 	}
 

--- a/daddy-heimlich/functions/class-daddio-instagram-locations.php
+++ b/daddy-heimlich/functions/class-daddio-instagram-locations.php
@@ -26,8 +26,6 @@ class Daddio_Instagram_Locations {
 		add_action( 'init', array( $this, 'action_init' ) );
 		add_action( 'daddio_after_instagram_inserted', array( $this, 'action_daddio_after_instagram_inserted' ), 10, 2 );
 		add_action( 'location_edit_form_fields', array( $this, 'action_location_edit_form_fields' ), 11 );
-
-		add_filter( 'daddio_pre_insert_instagram_post_args', array( $this, 'filter_daddio_pre_insert_instagram_post_args' ), 10, 2 );
 	}
 
 	/**
@@ -121,6 +119,14 @@ class Daddio_Instagram_Locations {
 					$append = true
 				);
 			}
+			update_post_meta( $post_id, 'instagram_location_id', $location_data['id'] );
+		}
+
+		if ( ! empty( $location_data['lat'] ) ) {
+			update_post_meta( $post_id, 'latitude', $location_data['lat'] );
+		}
+		if ( ! empty( $location_data['lng'] ) ) {
+			update_post_meta( $post_id, 'longitude', $location_data['lng'] );
 		}
 
 		if ( ! empty( $location_data['postcode'] ) ) {
@@ -226,25 +232,6 @@ class Daddio_Instagram_Locations {
 		</tr>
 		<?php
 		return ob_get_clean();
-	}
-
-	public function filter_daddio_pre_insert_instagram_post_args( $post_args, $node = array() ) {
-		// Store location id as post_meta if there is one
-		if ( ! empty( $node->location_id ) ) {
-			$post_args['meta_input']['instagram_location_id'] = $node->location_id;
-		}
-
-		$location_data = $this->get_location_data_from_node( $node );
-		if ( ! empty( $location_data ) ) {
-			if ( isset( $location_data['lat'] ) ) {
-				$post_args['meta_input']['latitude'] = $location_data['lat'];
-			}
-			if ( isset( $location_data['lng'] ) ) {
-				$post_args['meta_input']['longitude'] = $location_data['lng'];
-			}
-		}
-
-		return $post_args;
 	}
 
 	public function get_location_data_from_node( $node = array() ) {

--- a/daddy-heimlich/functions/class-daddio-instagram-locations.php
+++ b/daddy-heimlich/functions/class-daddio-instagram-locations.php
@@ -276,6 +276,9 @@ class Daddio_Instagram_Locations {
 					'slug'        => $args['slug'],
 				)
 			);
+			if ( ! is_wp_error( $term ) ) {
+				$term = (object) $term;
+			}
 		}
 		if ( isset( $term->term_id ) ) {
 			wp_set_object_terms(

--- a/daddy-heimlich/functions/class-daddio-instagram-locations.php
+++ b/daddy-heimlich/functions/class-daddio-instagram-locations.php
@@ -92,9 +92,6 @@ class Daddio_Instagram_Locations {
 
 	public function action_daddio_after_instagram_inserted( $post_id, $node ) {
 		$location_data = $this->get_location_data_from_node( $node );
-		// $location_data might not be complete at this point
-		// Maybe get it again?
-		// Example, County data is set but county is not associated with the instagram post
 
 		if ( empty( $location_data ) ) {
 			$description = 'No location set';
@@ -105,6 +102,7 @@ class Daddio_Instagram_Locations {
 				'post_id'          => $post_id,
 			);
 			$this->maybe_add_term_and_associate_with_post( $args );
+			update_post_meta( $post_id, 'instagram_location_id', 0 );
 			return;
 		}
 

--- a/daddy-heimlich/functions/class-daddio-instagram-locations.php
+++ b/daddy-heimlich/functions/class-daddio-instagram-locations.php
@@ -1,0 +1,391 @@
+<?php
+class Daddio_Instagram_Locations {
+
+	/**
+	 * Get an instance of this class
+	 */
+	public static function get_instance() {
+		static $instance = null;
+		if ( null === $instance ) {
+			// Late static binding (PHP 5.3+)
+			$instance = new static();
+			$instance->setup();
+			$instance->setup_hooks();
+		}
+		return $instance;
+	}
+
+	public function setup() {
+		$this->instagram_class = Daddio_Instagram::get_instance();
+	}
+
+	/**
+	 * Hook in to WordPress via actions and filters
+	 */
+	public function setup_hooks() {
+		add_action( 'init', array( $this, 'action_init' ) );
+		add_action( 'daddio_after_instagram_inserted', array( $this, 'action_daddio_after_instagram_inserted' ), 10, 2 );
+
+		add_filter( 'daddio_pre_insert_instagram_post_args', array( $this, 'filter_daddio_pre_insert_instagram_post_args' ), 10, 2 );
+	}
+
+	/**
+	 * Setup taxonomies
+	 */
+	function action_init() {
+		$args = array(
+			'labels'            => daddio_generate_taxonomy_labels( 'location', 'locations' ),
+			'hierarchical'      => true,
+			'public'            => true,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'show_in_nav_menus' => true,
+			'show_tagcloud'     => true,
+		);
+		register_taxonomy( 'location', array( 'instagram' ), $args );
+
+		$args = array(
+			'labels'            => daddio_generate_taxonomy_labels( 'zip code', 'zip codes' ),
+			'hierarchical'      => false,
+			'public'            => true,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'show_in_nav_menus' => true,
+			'show_tagcloud'     => true,
+		);
+		register_taxonomy( 'zip-code', array( 'instagram' ), $args );
+
+		$args = array(
+			'labels'            => daddio_generate_taxonomy_labels( 'state', 'states' ),
+			'hierarchical'      => false,
+			'public'            => true,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'show_in_nav_menus' => true,
+			'show_tagcloud'     => true,
+		);
+		register_taxonomy( 'state', array( 'instagram' ), $args );
+
+		$args = array(
+			'labels'            => daddio_generate_taxonomy_labels( 'county', 'counties' ),
+			'hierarchical'      => false,
+			'public'            => true,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'show_in_nav_menus' => true,
+			'show_tagcloud'     => true,
+		);
+		register_taxonomy( 'county', array( 'instagram' ), $args );
+
+		$args = array(
+			'labels'            => daddio_generate_taxonomy_labels( 'country', 'countries' ),
+			'hierarchical'      => false,
+			'public'            => true,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'show_in_nav_menus' => true,
+			'show_tagcloud'     => true,
+		);
+		register_taxonomy( 'country', array( 'instagram' ), $args );
+	}
+
+	public function action_daddio_after_instagram_inserted( $post_id, $node ) {
+		$location_data = $this->get_location_data_from_node( $node );
+		if ( empty( $location_data ) ) {
+			return;
+		}
+
+		if ( ! empty( $location_data['postcode'] ) ) {
+			$description = $location_data['city'] . ', ' . $this->get_state_abbreviation( $location_data['state'] );
+			$args = array(
+				'term_name'        => $location_data['postcode'],
+				'term_description' => $description,
+				'taxonomy'         => 'zip-code',
+				'post_id'          => $post_id,
+			);
+			$this->maybe_add_term_and_associate_with_post( $args );
+		}
+
+		/*
+		State
+		county
+		Country
+		 */
+	}
+
+	public function filter_daddio_pre_insert_instagram_post_args( $post_args, $node = array() ) {
+		// Store location id as post_meta if there is one
+		if ( ! empty( $node->location_id ) ) {
+			$post_args['meta_input']['instagram_location_id'] = $node->location_id;
+		}
+
+		$location_data = $this->get_location_data_from_node( $node );
+		if ( ! empty( $location_data ) ) {
+			if ( isset( $location_data['lat'] ) ) {
+				$post_args['meta_input']['latitude'] = $location_data['lat'];
+			}
+			if ( isset( $location_data['lng'] ) ) {
+				$post_args['meta_input']['longitude'] = $location_data['lng'];
+			}
+		}
+
+		return $post_args;
+	}
+
+	public function get_location_data_from_node( $node = array() ) {
+		$location_term_id = false;
+		if ( ! empty( $node->location_id ) ) {
+			$location_args = array(
+				'id'              => $node->location_id,
+				'name'            => $node->location_name,
+				'slug'            => $node->location_slug,
+				'has_public_page' => $node->location_has_public_page,
+			);
+			$location_term_id = $this->maybe_add_location( $location_args );
+			return $this->get_location_data( $location_term_id );
+		}
+		return array();
+	}
+
+	public function maybe_add_term_and_associate_with_post( $args = array() ) {
+		$default_args = array(
+			'term_name' => '',
+			'term_description' => '',
+			'taxonomy' => '',
+			'post_id' => 0,
+		);
+		$args = wp_parse_args( $args, $default_args );
+
+		$term = get_term_by(
+			$field = 'name',
+			$args['term_name'],
+			$args['taxonomy']
+		);
+		if ( $term === false ) {
+			$term = wp_insert_term(
+				$args['term_name'],
+				$args['taxonomy'],
+				array(
+					'description' => $args['term_description'],
+				)
+			);
+		}
+		if ( isset( $term->term_id ) ) {
+			$term_id = ;
+			wp_set_object_terms(
+				$args['post_id'],
+				$term->term_id,
+				$args['taxonomy'],
+				$append = true
+			);
+		}
+	}
+
+	public function maybe_add_location( $args = array() ) {
+		global $wpdb;
+
+		$default_args = array(
+			'id'              => '',
+			'name'            => '',
+			'slug'            => '',
+			'has_public_page' => '',
+		);
+		$args = wp_parse_args( $args, $default_args );
+		if ( empty( $args['id'] ) ) {
+			return false;
+		}
+
+		$meta_key = 'instagram-location-id';
+		$meta_value = $args['id'];
+
+		$term_id = $wpdb->get_var( $wpdb->prepare(
+			"
+				SELECT `term_id`
+				FROM `{$wpdb->termmeta}`
+				WHERE `meta_key` = %s
+				AND `meta_value` = %s
+				LIMIT 0,1;
+			",
+			$meta_key,
+			$meta_value
+		) );
+		if ( $term_id ) {
+			return $term_id;
+		}
+		$raw_location_data = $this->fetch_instagram_location( $args['id'] );
+		$location_data = array(
+			'id'              => '',
+			'name'            => '',
+			'has_public_page' => '',
+			'lat'             => '',
+			'lng'             => '',
+			'slug'            => '',
+		);
+		if ( isset( $raw_location_data->entry_data->LocationsPage[0]->location ) ) {
+			$location_obj = $raw_location_data->entry_data->LocationsPage[0]->location;
+			foreach ( $location_data as $key => $val ) {
+				if ( isset( $location_obj->{ $key } ) ) {
+					$location_data[ $key ] = $location_obj->{ $key };
+				}
+			}
+		}
+		$address_data = array();
+		if ( ! empty( $location_data['lat'] ) && ! empty( $location_data['lng'] ) ) {
+			$address_data = $this->reverse_geocode( $location_data['lat'], $location_data['lng'] );
+		}
+
+		$location_data = array_merge( $location_data, $address_data );
+		$custom_slug = $args['slug'] . '-' . $args['id'];
+		$term_args = array(
+			'slug' => $custom_slug,
+		);
+		$term = wp_insert_term( $args['name'], $taxonomy = 'location', $term_args );
+		if ( ! is_array( $term ) || empty( $term['term_id'] ) || is_wp_error( $term ) ) {
+			return 0;
+		}
+		$term_id = intval( $term['term_id'] );
+		add_term_meta( $term_id, $meta_key, $meta_value );
+		add_term_meta( $term_id, 'latitude', $location_data['lat'] );
+		add_term_meta( $term_id, 'longitude', $location_data['lng'] );
+		add_term_meta( $term_id, 'instagram-last-updated', time() );
+		add_term_meta( $term_id, 'location-data', $location_data );
+		return $term_id;
+	}
+
+	public function fetch_instagram_location( $location_id = '' ) {
+		if ( ! $location_id ) {
+			return false;
+		}
+		$request = 'https://www.instagram.com/explore/locations/' . $location_id . '/';
+		$response = wp_remote_get( $request );
+
+		return $this->instagram_class->get_instagram_json_from_html( $response['body'] );
+	}
+
+	public function get_location_data( $term = '' ) {
+		$term_id = false;
+		if ( is_numeric( $term ) ) {
+			$term_id = $term;
+		} else {
+			$term = get_term( $term, 'location' );
+			if ( is_object( $term ) && isset( $term->term_id ) ) {
+				$term_id = $term->term_id;
+			}
+		}
+		if ( ! $term_id ) {
+			return array();
+		}
+		return get_term_meta( $term_id, 'location-data', true );
+	}
+
+	public function reverse_geocode( $lat = '', $long = '' ) {
+		$output = array(
+			'locality'      => '',
+			'city'          => '',
+			'county'        => '',
+			'state'         => '',
+			'postcode'      => '',
+			'country'       => '',
+			'country_code'  => '',
+		);
+		if ( empty( $lat ) || empty( $long ) ) {
+			return $output;
+		}
+		$query_args = array(
+			'format'         => 'json',
+			'lat'            => $lat,
+			'lon'            => $long,
+			'zoom'           => 80,
+			'addressdetails' => 1,
+		);
+		$request = add_query_arg( $query_args, 'https://nominatim.openstreetmap.org/reverse' );
+		wp_log( $request );
+		$response = wp_remote_get( $request );
+		$body = $response['body'];
+		if ( ! is_string( $body ) || empty( $body ) ) {
+			return $output;
+		}
+		$json = json_decode( $response['body'] );
+		if ( isset( $json->address ) ) {
+			$output = wp_parse_args( $json->address, $output );
+		}
+		if ( isset( $output['postcode'] ) && empty( $output['city'] ) ) {
+			// Get city data
+			$request = 'https://api.zippopotam.us/us/' . $output['postcode'];
+			$response = wp_remote_get( $request );
+			$body = $response['body'];
+			if ( is_string( $body ) && ! empty( $body ) ) {
+				$json = json_decode( $body );
+				if ( isset( $json->places[0]->{'place name'} ) ) {
+					$output['city'] = $json->places[0]->{'place name'};
+				}
+			}
+		}
+		return $output;
+	}
+
+	public function get_state_abbreviation( $state = '' ) {
+		$key = ucwords( strtolower( $state ) );
+		// via https://gist.github.com/maxrice/2776900#gistcomment-1172963
+		$states = array(
+			'Alabama'        => 'AL',
+			'Alaska'         => 'AK',
+			'Arizona'        => 'AZ',
+			'Arkansas'       => 'AR',
+			'California'     => 'CA',
+			'Colorado'       => 'CO',
+			'Connecticut'    => 'CT',
+			'Delaware'       => 'DE',
+			'District of Columbia' => 'DC',
+			'Florida'        => 'FL',
+			'Georgia'        => 'GA',
+			'Hawaii'         => 'HI',
+			'Idaho'          => 'ID',
+			'Illinois'       => 'IL',
+			'Indiana'        => 'IN',
+			'Iowa'           => 'IA',
+			'Kansas'         => 'KS',
+			'Kentucky'       => 'KY',
+			'Louisiana'      => 'LA',
+			'Maine'          => 'ME',
+			'Maryland'       => 'MD',
+			'Massachusetts'  => 'MA',
+			'Michigan'       => 'MI',
+			'Minnesota'      => 'MN',
+			'Mississippi'    => 'MS',
+			'Missouri'       => 'MO',
+			'Montana'        => 'MT',
+			'Nebraska'       => 'NE',
+			'Nevada'         => 'NV',
+			'New Hampshire'  => 'NH',
+			'New Jersey'     => 'NJ',
+			'New Mexico'     => 'NM',
+			'New York'       => 'NY',
+			'North Carolina' => 'NC',
+			'North Dakota'   => 'ND',
+			'Ohio'           => 'OH',
+			'Oklahoma'       => 'OK',
+			'Oregon'         => 'OR',
+			'Pennsylvania'   => 'PA',
+			'Rhode Island'   => 'RI',
+			'South Carolina' => 'SC',
+			'South Dakota'   => 'SD',
+			'Tennessee'      => 'TN',
+			'Texas'          => 'TX',
+			'Utah'           => 'UT',
+			'Vermont'        => 'VT',
+			'Virginia'       => 'VA',
+			'Washington'     => 'WA',
+			'West Virginia'  => 'WV',
+			'Wisconsin'      => 'WI',
+			'Wyoming'        => 'WY',
+		);
+
+		if ( isset( $states[ $key ] ) ) {
+			return $states[ $key ];
+		}
+		return false;
+	}
+
+}
+Daddio_Instagram_Locations::get_instance();

--- a/daddy-heimlich/functions/class-daddio-instagram-locations.php
+++ b/daddy-heimlich/functions/class-daddio-instagram-locations.php
@@ -97,7 +97,14 @@ class Daddio_Instagram_Locations {
 		// Example, County data is set but county is not associated with the instagram post
 
 		if ( empty( $location_data ) ) {
-			// TODO: Maybe we should tag it with a None location
+			$description = 'No location set';
+			$args = array(
+				'term_name'        => 'None',
+				'term_description' => $description,
+				'taxonomy'         => 'location',
+				'post_id'          => $post_id,
+			);
+			$this->maybe_add_term_and_associate_with_post( $args );
 			return;
 		}
 

--- a/daddy-heimlich/functions/class-daddio-instagram-locations.php
+++ b/daddy-heimlich/functions/class-daddio-instagram-locations.php
@@ -91,6 +91,10 @@ class Daddio_Instagram_Locations {
 	}
 
 	public function action_daddio_after_instagram_inserted( $post_id, $node ) {
+		$post = get_post( $post_id );
+		if ( $post->post_type != 'instagram' ) {
+			return;
+		}
 		$location_data = $this->get_location_data_from_node( $node );
 
 		if ( empty( $location_data ) ) {

--- a/daddy-heimlich/functions/class-daddio-instagram-locations.php
+++ b/daddy-heimlich/functions/class-daddio-instagram-locations.php
@@ -97,6 +97,7 @@ class Daddio_Instagram_Locations {
 		// Example, County data is set but county is not associated with the instagram post
 
 		if ( empty( $location_data ) ) {
+			// TODO: Maybe we should tag it with a None location
 			return;
 		}
 

--- a/daddy-heimlich/functions/class-daddio-instagram-locations.php
+++ b/daddy-heimlich/functions/class-daddio-instagram-locations.php
@@ -37,7 +37,7 @@ class Daddio_Instagram_Locations {
 		$args = array(
 			'labels'            => daddio_generate_taxonomy_labels( 'location', 'locations' ),
 			'hierarchical'      => false,
-			'public'            => true,
+			'public'            => false,
 			'show_ui'           => true,
 			'show_admin_column' => true,
 			'show_in_nav_menus' => true,
@@ -48,7 +48,7 @@ class Daddio_Instagram_Locations {
 		$args = array(
 			'labels'            => daddio_generate_taxonomy_labels( 'zip code', 'zip codes' ),
 			'hierarchical'      => false,
-			'public'            => true,
+			'public'            => false,
 			'show_ui'           => true,
 			'show_admin_column' => false,
 			'show_in_nav_menus' => true,
@@ -59,7 +59,7 @@ class Daddio_Instagram_Locations {
 		$args = array(
 			'labels'            => daddio_generate_taxonomy_labels( 'state', 'states' ),
 			'hierarchical'      => false,
-			'public'            => true,
+			'public'            => false,
 			'show_ui'           => true,
 			'show_admin_column' => false,
 			'show_in_nav_menus' => true,
@@ -70,7 +70,7 @@ class Daddio_Instagram_Locations {
 		$args = array(
 			'labels'            => daddio_generate_taxonomy_labels( 'county', 'counties' ),
 			'hierarchical'      => false,
-			'public'            => true,
+			'public'            => false,
 			'show_ui'           => true,
 			'show_admin_column' => false,
 			'show_in_nav_menus' => true,
@@ -81,7 +81,7 @@ class Daddio_Instagram_Locations {
 		$args = array(
 			'labels'            => daddio_generate_taxonomy_labels( 'country', 'countries' ),
 			'hierarchical'      => false,
-			'public'            => true,
+			'public'            => false,
 			'show_ui'           => true,
 			'show_admin_column' => false,
 			'show_in_nav_menus' => true,

--- a/daddy-heimlich/functions/class-daddio-instagram.php
+++ b/daddy-heimlich/functions/class-daddio-instagram.php
@@ -74,72 +74,6 @@ class Daddio_Instagram {
 			'capability_type'     => 'page',
 		);
 		register_post_type( 'instagram', $args );
-
-		$labels = array(
-			'name'                       => 'Locations',
-			'singular_name'              => 'Location',
-			'menu_name'                  => 'Locations',
-			'all_items'                  => 'All Locations',
-			'parent_item'                => 'Parent Location',
-			'parent_item_colon'          => 'Parent Location:',
-			'new_item_name'              => 'New Location Name',
-			'add_new_item'               => 'Add New Location',
-			'edit_item'                  => 'Edit Location',
-			'update_item'                => 'Update Location',
-			'view_item'                  => 'View Location',
-			'separate_items_with_commas' => 'Separate locations with commas',
-			'add_or_remove_items'        => 'Add or remove locations',
-			'choose_from_most_used'      => 'Choose from the most used',
-			'popular_items'              => 'Popular Locations',
-			'search_items'               => 'Search Locations',
-			'not_found'                  => 'Not Found',
-			'no_terms'                   => 'No locations',
-			'items_list'                 => 'Locations list',
-			'items_list_navigation'      => 'Locations list navigation',
-		);
-		$args = array(
-			'labels'                     => $labels,
-			'hierarchical'               => true,
-			'public'                     => true,
-			'show_ui'                    => true,
-			'show_admin_column'          => true,
-			'show_in_nav_menus'          => true,
-			'show_tagcloud'              => true,
-		);
-		register_taxonomy( 'location', array( 'instagram' ), $args );
-
-		$labels = array(
-			'name'                       => 'Zip Codes',
-			'singular_name'              => 'Zip Code',
-			'menu_name'                  => 'Zip Codes',
-			'all_items'                  => 'All Zip Codes',
-			'parent_item'                => 'Parent Zip Code',
-			'parent_item_colon'          => 'Parent Zip Code:',
-			'new_item_name'              => 'New Zip Code Name',
-			'add_new_item'               => 'Add New Zip Code',
-			'edit_item'                  => 'Edit Zip Code',
-			'update_item'                => 'Update Zip Code',
-			'view_item'                  => 'View Zip Code',
-			'separate_items_with_commas' => 'Separate zip codes with commas',
-			'add_or_remove_items'        => 'Add or remove zip codes',
-			'choose_from_most_used'      => 'Choose from the most used',
-			'popular_items'              => 'Popular Zip Codes',
-			'search_items'               => 'Search Zip Codes',
-			'not_found'                  => 'Not Found',
-			'no_terms'                   => 'No zip codes',
-			'items_list'                 => 'Zip codes list',
-			'items_list_navigation'      => 'Zip codes list navigation',
-		);
-		$args = array(
-			'labels'                     => $labels,
-			'hierarchical'               => false,
-			'public'                     => true,
-			'show_ui'                    => true,
-			'show_admin_column'          => true,
-			'show_in_nav_menus'          => true,
-			'show_tagcloud'              => true,
-		);
-		register_taxonomy( 'zip-code', array( 'instagram' ), $args );
 	}
 
 	/**
@@ -223,8 +157,8 @@ class Daddio_Instagram {
 		$query->set( 'tax_query', array(
 			array(
 				'taxonomy' => 'post_tag',
-				'field'	=> 'id',
-				'terms'	=> $tag_ids,
+				'field'	   => 'id',
+				'terms'	   => $tag_ids,
 				'operator' => 'NOT IN',
 			),
 		) );
@@ -588,16 +522,6 @@ class Daddio_Instagram {
 		return $this->get_instagram_json_from_html( $response['body'] );
 	}
 
-	public function fetch_instagram_location( $location_id = '' ) {
-		if ( ! $location_id ) {
-			return false;
-		}
-		$request = 'https://www.instagram.com/explore/locations/' . $location_id . '/';
-		$response = wp_remote_get( $request );
-
-		return $this->get_instagram_json_from_html( $response['body'] );
-	}
-
 	/**
 	 * Fetch a single Instagram page/data from a given code
 	 *
@@ -801,18 +725,6 @@ class Daddio_Instagram {
 		$caption = wp_encode_emoji( $node->caption );
 		$title = preg_replace( '/\s#\w+/i', '', $caption );
 
-		$location_term_id = false;
-		if ( ! empty( $node->location_id ) ) {
-			$location_args = array(
-				'id'              => $node->location_id,
-				'name'            => $node->location_name,
-				'slug'            => $node->location_slug,
-				'has_public_page' => $node->location_has_public_page,
-			);
-			$location_term_id = $this->maybe_add_location( $location_args );
-			$location_data = $this->get_location_data( $location_term_id );
-		}
-
 		$default_post_args = array(
 			'post_title'    => $title,
 			'post_content'  => $caption,
@@ -833,20 +745,7 @@ class Daddio_Instagram {
 		}
 		$post_args['post_content'] = wp_encode_emoji( $post_args['post_content'] );
 
-		// Store location id as post_meta if there is one
-		if ( ! empty( $node->location_id ) ) {
-			$post_args['meta_input']['instagram_location_id'] = $node->location_id;
-		}
-
-		if ( ! empty( $location_data ) ) {
-			if ( isset( $location_data['lat'] ) ) {
-				$post_args['meta_input']['latitude'] = $location_data['lat'];
-			}
-			if ( isset( $location_data['lng'] ) ) {
-				$post_args['meta_input']['longitude'] = $location_data['lng'];
-			}
-		}
-
+		$post_args = apply_filters( 'daddio_pre_insert_instagram_post_args', $post_args, $node );
 		$inserted = wp_insert_post( $post_args );
 
 		// Handle children
@@ -930,42 +829,7 @@ class Daddio_Instagram {
 			add_post_meta( $inserted, '_video_id', $video_id );
 		}
 
-		// Do some more location data tagging
-		if ( ! empty( $location_data ) ) {
-
-			if ( ! empty( $location_data['postcode'] ) ) {
-				$term = get_term_by(
-					$field = 'name',
-					$value = $location_data['postcode'],
-					$taxonomy = 'zip-code'
-				);
-				if ( $term === false ) {
-					$description = $location_data['city'] . ', ' . $this->get_state_abbreviation( $location_data['state'] );
-					$term = wp_insert_term(
-						$location_data['postcode'],
-						$taxonomy = 'zip-code',
-						array(
-							'description' => $description,
-						)
-					);
-				}
-				if ( isset( $term->term_id ) ) {
-					$term_id = $term->term_id;
-					wp_set_object_terms(
-						$object_id = $inserted,
-						$term_id,
-						'zip-code',
-						$append = true
-					);
-				}
-			}
-
-			/*
-			State
-			county
-			Country
-			 */
-		}
+		do_action( 'daddio_after_instagram_inserted', $inserted, $node );
 
 		return (object) array(
 			'post_id'  => $inserted,
@@ -1057,202 +921,6 @@ class Daddio_Instagram {
 
 			return $id;
 		}
-	}
-
-	public function maybe_add_location( $args = array() ) {
-		global $wpdb;
-
-		$default_args = array(
-			'id'              => '',
-			'name'            => '',
-			'slug'            => '',
-			'has_public_page' => '',
-		);
-		$args = wp_parse_args( $args, $default_args );
-		if ( empty( $args['id'] ) ) {
-			return false;
-		}
-
-		$meta_key = 'instagram-location-id';
-		$meta_value = $args['id'];
-
-		$term_id = $wpdb->get_var( $wpdb->prepare(
-			"
-				SELECT `term_id`
-				FROM `{$wpdb->termmeta}`
-				WHERE `meta_key` = %s
-				AND `meta_value` = %s
-				LIMIT 0,1;
-			",
-			$meta_key,
-			$meta_value
-		) );
-		if ( $term_id ) {
-			return $term_id;
-		}
-		$raw_location_data = $this->fetch_instagram_location( $args['id'] );
-		$location_data = array(
-			'id'              => '',
-			'name'            => '',
-			'has_public_page' => '',
-			'lat'             => '',
-			'lng'             => '',
-			'slug'            => '',
-		);
-		if ( isset( $raw_location_data->entry_data->LocationsPage[0]->location ) ) {
-			$location_obj = $raw_location_data->entry_data->LocationsPage[0]->location;
-			foreach ( $location_data as $key => $val ) {
-				if ( isset( $location_obj->{ $key } ) ) {
-					$location_data[ $key ] = $location_obj->{ $key };
-				}
-			}
-		}
-		$address_data = array();
-		if ( ! empty( $location_data['lat'] ) && ! empty( $location_data['lng'] ) ) {
-			$address_data = $this->reverse_geocode( $location_data['lat'], $location_data['lng'] );
-		}
-
-		$location_data = array_merge( $location_data, $address_data );
-		$custom_slug = $args['slug'] . '-' . $args['id'];
-		$term_args = array(
-			'slug' => $custom_slug,
-		);
-		$term = wp_insert_term( $args['name'], $taxonomy = 'location', $term_args );
-		if ( ! is_array( $term ) || empty( $term['term_id'] ) || is_wp_error( $term ) ) {
-			return 0;
-		}
-		$term_id = intval( $term['term_id'] );
-		add_term_meta( $term_id, $meta_key, $meta_value );
-		add_term_meta( $term_id, 'latitude', $location_data['lat'] );
-		add_term_meta( $term_id, 'longitude', $location_data['lng'] );
-		add_term_meta( $term_id, 'instagram-last-updated', time() );
-		add_term_meta( $term_id, 'location-data', $location_data );
-		return $term_id;
-	}
-
-	public function reverse_geocode( $lat = '', $long = '' ) {
-		$output = array(
-			'locality'      => '',
-			'city'          => '',
-			'county'        => '',
-			'state'         => '',
-			'postcode'      => '',
-			'country'       => '',
-			'country_code'  => '',
-		);
-		if ( empty( $lat ) || empty( $long ) ) {
-			return $output;
-		}
-		$query_args = array(
-			'format'         => 'json',
-			'lat'            => $lat,
-			'lon'            => $long,
-			'zoom'           => 80,
-			'addressdetails' => 1,
-		);
-		$request = add_query_arg( $query_args, 'https://nominatim.openstreetmap.org/reverse' );
-		wp_log( $request );
-		$response = wp_remote_get( $request );
-		$body = $response['body'];
-		if ( ! is_string( $body ) || empty( $body ) ) {
-			return $output;
-		}
-		$json = json_decode( $response['body'] );
-		if ( isset( $json->address ) ) {
-			$output = wp_parse_args( $json->address, $output );
-		}
-		if ( isset( $output['postcode'] ) && empty( $output['city'] ) ) {
-			// Get city data
-			$request = 'https://api.zippopotam.us/us/' . $output['postcode'];
-			$response = wp_remote_get( $request );
-			$body = $response['body'];
-			if ( is_string( $body ) && ! empty( $body ) ) {
-				$json = json_decode( $body );
-				if ( isset( $json->places[0]->{'place name'} ) ) {
-					$output['city'] = $json->places[0]->{'place name'};
-				}
-			}
-		}
-		return $output;
-	}
-
-	public function get_location_data( $term = '' ) {
-		$term_id = false;
-		if ( is_numeric( $term ) ) {
-			$term_id = $term;
-		} else {
-			$term = get_term( $term, 'location' );
-			if ( is_object( $term ) && isset( $term->term_id ) ) {
-				$term_id = $term->term_id;
-			}
-		}
-		if ( ! $term_id ) {
-			return array();
-		}
-		return get_term_meta( $term_id, 'location-data', true );
-	}
-
-	public function get_state_abbreviation( $state = '' ) {
-		$key = ucwords( strtolower( $state ) );
-		// via https://gist.github.com/maxrice/2776900#gistcomment-1172963
-		$states = array(
-			'Alabama'        => 'AL',
-			'Alaska'         => 'AK',
-			'Arizona'        => 'AZ',
-			'Arkansas'       => 'AR',
-			'California'     => 'CA',
-			'Colorado'       => 'CO',
-			'Connecticut'    => 'CT',
-			'Delaware'       => 'DE',
-			'District of Columbia' => 'DC',
-			'Florida'        => 'FL',
-			'Georgia'        => 'GA',
-			'Hawaii'         => 'HI',
-			'Idaho'          => 'ID',
-			'Illinois'       => 'IL',
-			'Indiana'        => 'IN',
-			'Iowa'           => 'IA',
-			'Kansas'         => 'KS',
-			'Kentucky'       => 'KY',
-			'Louisiana'      => 'LA',
-			'Maine'          => 'ME',
-			'Maryland'       => 'MD',
-			'Massachusetts'  => 'MA',
-			'Michigan'       => 'MI',
-			'Minnesota'      => 'MN',
-			'Mississippi'    => 'MS',
-			'Missouri'       => 'MO',
-			'Montana'        => 'MT',
-			'Nebraska'       => 'NE',
-			'Nevada'         => 'NV',
-			'New Hampshire'  => 'NH',
-			'New Jersey'     => 'NJ',
-			'New Mexico'     => 'NM',
-			'New York'       => 'NY',
-			'North Carolina' => 'NC',
-			'North Dakota'   => 'ND',
-			'Ohio'           => 'OH',
-			'Oklahoma'       => 'OK',
-			'Oregon'         => 'OR',
-			'Pennsylvania'   => 'PA',
-			'Rhode Island'   => 'RI',
-			'South Carolina' => 'SC',
-			'South Dakota'   => 'SD',
-			'Tennessee'      => 'TN',
-			'Texas'          => 'TX',
-			'Utah'           => 'UT',
-			'Vermont'        => 'VT',
-			'Virginia'       => 'VA',
-			'Washington'     => 'WA',
-			'West Virginia'  => 'WV',
-			'Wisconsin'      => 'WI',
-			'Wyoming'        => 'WY',
-		);
-
-		if ( isset( $states[ $key ] ) ) {
-			return $states[ $key ];
-		}
-		return false;
 	}
 }
 Daddio_Instagram::get_instance();

--- a/daddy-heimlich/functions/class-daddio-instagram.php
+++ b/daddy-heimlich/functions/class-daddio-instagram.php
@@ -961,7 +961,6 @@ class Daddio_Instagram {
 			}
 
 			/*
-			Zip Code
 			State
 			county
 			Country

--- a/daddy-heimlich/functions/class-daddio-instagram.php
+++ b/daddy-heimlich/functions/class-daddio-instagram.php
@@ -231,8 +231,19 @@ class Daddio_Instagram {
 
 			// It's a Tag page
 			if ( isset( $json->entry_data->TagPage[0] ) ) {
-				$top_posts = $json->entry_data->TagPage[0]->tag->top_posts->nodes;
-				$other = $json->entry_data->TagPage[0]->tag->media->nodes;
+				$top_posts = array();
+				$other = array();
+
+				if ( isset( $json->entry_data->TagPage[0]->tag ) ) {
+					$top_posts = $json->entry_data->TagPage[0]->tag->top_posts->nodes;
+					$other = $json->entry_data->TagPage[0]->tag->media->nodes;
+				}
+
+				// New format I detected on 01/02/2018
+				if ( isset( $json->entry_data->TagPage[0]->graphql->hashtag ) ) {
+					$top_posts = $json->entry_data->TagPage[0]->graphql->hashtag->edge_hashtag_to_top_posts->edges;
+					$other = $json->entry_data->TagPage[0]->graphql->hashtag->edge_hashtag_to_media->edges;
+				}
 				$nodes = array_merge( $top_posts, $other );
 			}
 
@@ -582,6 +593,9 @@ class Daddio_Instagram {
 			'location_has_public_page' => false,
 			'children'                 => array(),
 		);
+		if ( isset( $node->node ) ) {
+			$node = $node->node;
+		}
 
 		// Common properties for both old and new format
 		if ( isset( $node->id ) ) {

--- a/daddy-heimlich/functions/class-daddio-instagram.php
+++ b/daddy-heimlich/functions/class-daddio-instagram.php
@@ -74,6 +74,39 @@ class Daddio_Instagram {
 			'capability_type'     => 'page',
 		);
 		register_post_type( 'instagram', $args );
+
+		$labels = array(
+			'name'                       => 'Locations',
+			'singular_name'              => 'Location',
+			'menu_name'                  => 'Locations',
+			'all_items'                  => 'All Locations',
+			'parent_item'                => 'Parent Location',
+			'parent_item_colon'          => 'Parent Location:',
+			'new_item_name'              => 'New Location Name',
+			'add_new_item'               => 'Add New Location',
+			'edit_item'                  => 'Edit Location',
+			'update_item'                => 'Update Location',
+			'view_item'                  => 'View Location',
+			'separate_items_with_commas' => 'Separate locations with commas',
+			'add_or_remove_items'        => 'Add or remove locations',
+			'choose_from_most_used'      => 'Choose from the most used',
+			'popular_items'              => 'Popular Locations',
+			'search_items'               => 'Search Locations',
+			'not_found'                  => 'Not Found',
+			'no_terms'                   => 'No locations',
+			'items_list'                 => 'Locations list',
+			'items_list_navigation'      => 'Locations list navigation',
+		);
+		$args = array(
+			'labels'                     => $labels,
+			'hierarchical'               => true,
+			'public'                     => true,
+			'show_ui'                    => true,
+			'show_admin_column'          => true,
+			'show_in_nav_menus'          => true,
+			'show_tagcloud'              => true,
+		);
+		register_taxonomy( 'location', array( 'instagram' ), $args );
 	}
 
 	/**

--- a/daddy-heimlich/functions/cli-commands.php
+++ b/daddy-heimlich/functions/cli-commands.php
@@ -47,23 +47,41 @@ function fix_zadies_instagram_images() {
 }
 WP_CLI::add_command( 'zah-fix-instagrams', 'fix_zadies_instagram_images' );
 
+function zah_prep_locations() {
+	$args = array(
+		'post_type'      => 'instagram',
+		'post_status'    => 'public',
+		'posts_per_page' => -1,
+	);
+	$query = new WP_Query( $args );
+	$count = 0;
+	foreach ( $query->posts as $post ) {
+		$post_id = $post->ID;
+		$has_location_id = get_post_meta( $post_id, 'instagram_location_id', true );
+		if ( ! $has_location_id ) {
+			update_post_meta( $post_id, 'needs-location-data', '1' );
+			$count++;
+		}
+	}
+	WP_CLI::success( number_format( $count ) . ' posts need location data out of ' . number_format( $query->found_posts ) . ' posts' );
+}
+WP_CLI::add_command( 'zah-prep-locations', 'zah_prep_locations' );
+
 function zah_add_locations() {
 	// Get all published instagram posts that don't have a instagram_location_id meta key set...
 	$args = array(
 		'post_type'      => 'instagram',
 		'post_status'    => 'public',
-		'posts_per_page' => 1,
+		'posts_per_page' => -1,
 		'meta_query'     => array(
 			array(
-				'key'     => 'instagram_location_id',
-				'compare' => 'NOT EXISTS',
+				'key'     => 'needs-location-data',
+				'value'   => '1',
+				'compare' => '=',
 			),
 		),
 	);
 	$query = new WP_Query( $args );
-	// @TODO Run through eahc post and get any location data from Instagram to process
-	// Probably need to call do_action( 'daddio_after_instagram_inserted' ) passing the post_id and the node data
-	// fetch_single_instagram() might be useful
 	$insta = Daddio_Instagram::get_instance();
 	foreach ( $query->posts as $post ) {
 		$post_id = $post->ID;
@@ -75,12 +93,14 @@ function zah_add_locations() {
 		if ( isset( $json->entry_data->PostPage[0] ) ) {
 			$node = $json->entry_data->PostPage[0]->graphql->shortcode_media;
 			$node = $insta->normalize_instagram_data( $node );
-			// do_action( 'daddio_after_instagram_inserted', $post_id, $node );
-			print_r( $node );
+			do_action( 'daddio_after_instagram_inserted', $post->ID, $node );
+			delete_post_meta( $post_id, 'needs-location-data' );
+			WP_CLI::line( $post_id . ' (https://www.instagram.com/p/' . $code . '/) is done' );
+		} else {
+			update_post_meta( $post_id, 'needs-private-location-data', '1' );
+			WP_CLI::line( 'PRIVATE: ' . $post_id . ' (https://www.instagram.com/p/' . $code . '/) is private!' );
 		}
-
-		WP_CLI::line( $post_id . ' (' . $code . ') is done' );
 	}
-	WP_CLI::success( 'Done!' );
+	WP_CLI::success( 'All Done!' );
 }
 WP_CLI::add_command( 'zah-add-locations', 'zah_add_locations' );

--- a/daddy-heimlich/functions/cli-commands.php
+++ b/daddy-heimlich/functions/cli-commands.php
@@ -46,3 +46,41 @@ function fix_zadies_instagram_images() {
 	WP_CLI::success( 'Done!' );
 }
 WP_CLI::add_command( 'zah-fix-instagrams', 'fix_zadies_instagram_images' );
+
+function zah_add_locations() {
+	// Get all published instagram posts that don't have a instagram_location_id meta key set...
+	$args = array(
+		'post_type'      => 'instagram',
+		'post_status'    => 'public',
+		'posts_per_page' => 1,
+		'meta_query'     => array(
+			array(
+				'key'     => 'instagram_location_id',
+				'compare' => 'NOT EXISTS',
+			),
+		),
+	);
+	$query = new WP_Query( $args );
+	// @TODO Run through eahc post and get any location data from Instagram to process
+	// Probably need to call do_action( 'daddio_after_instagram_inserted' ) passing the post_id and the node data
+	// fetch_single_instagram() might be useful
+	$insta = Daddio_Instagram::get_instance();
+	foreach ( $query->posts as $post ) {
+		$post_id = $post->ID;
+		$guid = $post->guid;
+		$parts = explode( 'com/p/', $guid );
+		$code = $parts[1];
+		$code = str_replace( '/', '', $code );
+		$json = $insta->fetch_single_instagram( $code );
+		if ( isset( $json->entry_data->PostPage[0] ) ) {
+			$node = $json->entry_data->PostPage[0]->graphql->shortcode_media;
+			$node = $insta->normalize_instagram_data( $node );
+			// do_action( 'daddio_after_instagram_inserted', $post_id, $node );
+			print_r( $node );
+		}
+
+		WP_CLI::line( $post_id . ' (' . $code . ') is done' );
+	}
+	WP_CLI::success( 'Done!' );
+}
+WP_CLI::add_command( 'zah-add-locations', 'zah_add_locations' );

--- a/daddy-heimlich/js/admin-private-location-sync-submenu.js
+++ b/daddy-heimlich/js/admin-private-location-sync-submenu.js
@@ -1,0 +1,32 @@
+jQuery(document).ready(function($) {
+	$('#wpbody').on('blur', '.instagram-source', function() {
+		var $this = $(this);
+		var instagramSource = $this.val();
+		if ( ! instagramSource ) {
+			return;
+		}
+		var $parent = $this.parent();
+		var $post = $this.parents('.post');
+		var postID = $parent.find('.post-id').val();
+		var data = {
+			'action': 'daddio_private_location_sync',
+			'post-id': postID,
+			'instagram-source': instagramSource
+		};
+		$post.addClass('loading')
+
+		$.post(ajaxurl, data )
+			.done(function(resp) {
+				var html = '<p class="success">' + resp.data.message + '</p>';
+				$parent.html( html );
+				$post.addClass('success');
+			})
+			.fail(function(resp) {
+				var html = '<p class="fail">' + resp.data.message + '</p>';
+				$parent.html( html );
+				$post.addClass('fail');
+			}).always(function() {
+				$post.removeClass('loading');
+			});
+	});
+});


### PR DESCRIPTION
Closes #7 

- Scrape location data from Instagram posts going forward
- Provide tools to backfill location data to previous posts
- Use the latitude and longitude data from Instagram to gather further geodata (street address, county, city ,state etc.)
- Add location specific taxonomies: location, state, city, country, zip code

For backfilling location data run these two CLI commands:
 - `wp zah-prep-locations --url=https://zadieheimlich.com`
 - `wp zah-add-locations --url=https://zadieheimlich.com`